### PR TITLE
fix bug

### DIFF
--- a/dist/angular.multi-select.js
+++ b/dist/angular.multi-select.js
@@ -20,7 +20,7 @@ directive('multiSelect', [function () {
             init(element, scope.msOptions);
 
             scope.$watch(function () {
-                return (ngModel && ngModel.$modelValue) || scope.multiSelect;
+                return (ngModel && ngModel.$modelValue && ngModel.$modelValue.length !== 0) || scope.multiSelect;
             }, function (n) {
                 refresh(element);
             });


### PR DESCRIPTION
If a variable is defined in the controller and referenced in the HTML. for example 
`angular.module('demo', ['jq-multi-select'])
.controller('ctrl', ['$scope', '$http', function ($scope, $http) {
    $scope.selectedOptions = [];
    ……
}]);`

` <select multiple data-ng-options="option as option for option in options" data-ng-model="selectedOptions" data-multi-select="options"></select>`

